### PR TITLE
Add sponsors section to event main page Add sponsors section to all event pages

### DIFF
--- a/content/events/2020-bouvet-island/_index.md
+++ b/content/events/2020-bouvet-island/_index.md
@@ -7,6 +7,28 @@ location:
   name: 'Bouvet Island, Antarctica'
 social:
   twitter: 'https://twitter.com/Bouvet_3Y0Z'
+sponsors:
+- level: diamond
+  orgs:
+  - name: Oceanic Airways
+    logo: oceanic-airways.svg
+    url: https://en.wikipedia.org/wiki/Oceanic_Airlines
+- level: platinum
+  orgs:
+  - name: BnL
+    logo: bnl.svg
+    url: https://pixar.fandom.com/wiki/Buy_n_Large
+- level: gold
+  orgs:
+  - name: Ghostbusters
+    logo: ghostbusters.svg
+    url: https://www.ghostbusters.com/
+  - name: Jurassic Park
+    logo: jurassic-park.svg
+    url: https://www.imdb.com/title/tt0107290/
+  - name: Staypuft
+    logo: staypuft.svg
+    url: https://en.wikipedia.org/wiki/Stay_Puft_Marshmallow_Man
 ---
 
 Kubernetes Community Day Bouvet Island is going to be the largest ever cloud native event in the Antarctic region, perhaps rivaling [KubeCon San Diego](https://events.linuxfoundation.org/events/kubecon-cloudnativecon-north-america-2019/) in size.

--- a/content/events/2020-bouvet-island/sponsors.md
+++ b/content/events/2020-bouvet-island/sponsors.md
@@ -1,27 +1,5 @@
 ---
 title: Sponsors
-sponsors:
-- level: diamond
-  orgs:
-  - name: Oceanic Airways
-    logo: oceanic-airways.svg
-    url: https://en.wikipedia.org/wiki/Oceanic_Airlines
-- level: platinum
-  orgs:
-  - name: BnL
-    logo: bnl.svg
-    url: https://pixar.fandom.com/wiki/Buy_n_Large
-- level: gold
-  orgs:
-  - name: Ghostbusters
-    logo: ghostbusters.svg
-    url: https://www.ghostbusters.com/
-  - name: Jurassic Park
-    logo: jurassic-park.svg
-    url: https://www.imdb.com/title/tt0107290/
-  - name: Staypuft
-    logo: staypuft.svg
-    url: https://en.wikipedia.org/wiki/Stay_Puft_Marshmallow_Man
 ---
 
 Kubernetes Community Day Bouvet Island is only possible because of the support of sponsors including:

--- a/layouts/events/section.html
+++ b/layouts/events/section.html
@@ -1,10 +1,6 @@
 {{ define "main" }}
-{{ $isRoot := eq .CurrentSection .FirstSection }}
 {{ partial "navbar.html" . }}
 {{ partial "events/hero.html" . }}
-
-{{ if $isRoot }}
-{{ partial "events/event-listing.html" . }}
-{{ end }}
 {{ partial "events/content.html" . }}
+{{ partial "events/sponsors.html" . }}
 {{ end }}

--- a/layouts/events/single.html
+++ b/layouts/events/single.html
@@ -2,4 +2,5 @@
 {{ partial "navbar.html" . }}
 {{ partial "events/hero.html" . }}
 {{ partial "events/content.html" . }}
+{{ partial "events/sponsors.html" . }}
 {{ end }}

--- a/layouts/partials/events/content.html
+++ b/layouts/partials/events/content.html
@@ -7,7 +7,3 @@
   </div>
 </section>
 {{ end }}
-
-{{ if eq .File.BaseFileName "sponsors" }}
-{{ partial "events/sponsors.html" . }}
-{{ end }}

--- a/layouts/partials/events/sponsors.html
+++ b/layouts/partials/events/sponsors.html
@@ -1,8 +1,21 @@
-{{ $sponsors := .Params.sponsors }}
+{{ $isEventRoot := eq .File.BaseFileName "_index" }}
+{{ $sponsors    := .CurrentSection.Params.sponsors }}
 
 {{ with $sponsors }}
+{{ if $isEventRoot }}
+<hr />
+{{ end }}
+
 <section class="section">
   <div class="container">
+    {{ if $isEventRoot }}
+    <p class="title is-size-2 is-size-3-mobile">
+      Sponsors
+    </p>
+
+    <br /><br />
+    {{ end }}
+
     {{ range . }}
     {{ $level := .level }}
     {{ $orgs  := .orgs }}


### PR DESCRIPTION
Resolves #42

See [here](https://deploy-preview-43--kubernetes-community-days.netlify.com/events/2020-bouvet-island/) for an example.