### PR TITLE
Eliminate tag metadata

### DIFF
--- a/layouts/partials/event-tile.html
+++ b/layouts/partials/event-tile.html
@@ -1,5 +1,3 @@
-{{ $tag    := .Params.tag }}
-{{ $img    := printf "img/places/%s" $tag | relURL }}
 {{ $url    := .RelPermalink }}
 {{ $title  := .Title }}
 {{ $date   := .Date | dateFormat "January 2, 2006" }}

--- a/layouts/partials/types/event.html
+++ b/layouts/partials/types/event.html
@@ -1,6 +1,5 @@
 {{ $title := .Title }}
-{{ $tag   := .Params.tag }}
-{{ $url   := cond (eq .Params.link nil) (printf "/events/%s" .Params.tag) .Params.link }}
+{{ $url   := .RelPermalink }}
 {{ $month := .Params.date | string | dateFormat "January" }}
 {{ $day   := .Params.date | dateFormat "2" }}
 {{ $year  := .Params.date | dateFormat "2006"}}


### PR DESCRIPTION
`.Params.tag` wasn't actually being used, so we can safely eliminate this.

Resolves #27