### PR TITLE
major changes to the organizing page

### DIFF
--- a/content/organizing.md
+++ b/content/organizing.md
@@ -13,30 +13,29 @@ We would like to give a generous thank you to [DevOpsDays](https://devopsdays.or
 ## Contact a specific event
 Kubernetes Community Days organization is decentralized. Local events handle their own sponsorships, registration, and all other logistics. For questions about a specific event you see listed on the site, contact the local organizers for that event; their email is on their contact page.
 
-## Interested in Organizing a Kubernetes Community Days?
-
 Check to see if there is a Kubernetes Community Days event scheduled in your area on the events page. If there is an event scheduled, please reach out to the organizers to express your interest in helping. You can find a list of current events being planned on the website along with contact details for the organizers.
 
-If there isn’t an event being organized, the first step in building out a successful event is assembling a team. You’ll need at minimum 3 other organizers from at least 2 different organizations.  Ideally, you’ll have 5 or more organizers. One of the organizers must be a CNCF Member employee, Ambassador, or CNCF project maintainer. You can ofter find local community members who may be interested in helping to organize or volunteer at local user groups and Meetups, such as the [CNCF Meetup groups](https://www.meetup.com/pro/cncf/).
+If there isn’t an event being organized, the first step in building out a successful event is assembling a team. You’ll need at minimum 3 other organizers from at least 2 different organizations.  Ideally, you’ll have 5 or more organizers. One of the organizers must be a CNCF Member employee, Ambassador, or CNCF project maintainer. You can often find local community members who may be interested in helping to organize or volunteer at local user groups and Meetups, such as the [CNCF Meetup groups](https://www.meetup.com/pro/cncf/).
 
-Check the GitHub Repo [porject board](https://github.com/cncf/kubernetes-community-days/projects/2) for other individuals who have expressed an interest in organizing an event in your area. If there are no GitHub issues for your area, create an [issue](https://github.com/cncf/kubernetes-community-days/issues/new?assignees=christinevblum%2C+iennae&labels=planningevent&template=interest.md) to express an interest in organizing an event in your area. 
+Check the GitHub Repo [project board](https://github.com/cncf/kubernetes-community-days/projects/2) for other individuals who have expressed an interest in organizing an event in your area. If there are no GitHub issues for your area, create an [issue](https://github.com/cncf/kubernetes-community-days/issues/new?assignees=christinevblum%2C+iennae&labels=planningevent&template=interest.md) to express an interest in organizing an event in your area. 
+
 CNCF helps support Kubernetes Community Days with guidance and promotion. We will cover all the key aspects of holding an event in the sections below, with break out documents for extended sections. 
 
-Keep in mind, Kubernetes Community Day events are visionary, educational, and provide user-driven content. Organizers need to avoid sales pitches in crafting the program for their event. Kubernetes Community Days events are inclusive. This also means making reasonable efforts to support others in the community who want to help organize, attend, or sponsor, regardless of their organizational affiliation.
+Keep in mind, Kubernetes Community Day events are visionary, educational, and provide user-driven content. Organizers need to avoid sales pitches in crafting the program for their event. Kubernetes Community Days events are inclusive. This also means making reasonable efforts to support others in the community who want to help organize, attend, or sponsor, regardless of their organizations affiliation.
 
 ## Getting Started Checklist
 
 * No other Kubernetes Community Day event in the local area
 * Minimum of 3 organizers from 2 different organizations
-* At least one organizer is a CNCF Member employee, Ambassador, or CNCF Project Maintainer
+* At least one organizer is a CNCF Member employee, Ambassador, or CNCF project maintainer
 * You have a method to accept payments including sponsorships and to payout expenses
-* All organizers have signed off to the event guidelines and CNCF Code of Conduct
+* All organizers have signed off to the event guidelines and [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
 * Organizers are local to the event location
 
-Once your organizing team has signed off on the event guidelines and completed the Getting Started checklist, create an [issue](https://github.com/cncf/kubernetes-community-days/issues/new?assignees=christinevblum%2C+iennae&labels=newevent&template=host.md) to get your event officially recognized. The event team will be invited to the Kubernetes Community Days Event Organizers Slack channel where you can connect with other Kubernetes Community Days organizers around the world. You can then begin creating your website, by copying the page structure of the [Bouvet Island](https://kubernetescommunitydays.org/events/2020-bouvet-island/) event. Here are directions to do so.
+Once your organizing team has signed off on the event guidelines and completed the Getting Started checklist, create an [issue](https://github.com/cncf/kubernetes-community-days/issues/new?assignees=christinevblum%2C+iennae&labels=newevent&template=host.md) to get your event officially recognized. The event team will be invited to the Kubernetes Community Days Event Organizers Slack channel where you can connect with other Kubernetes Community Days organizers around the world. You can then begin creating your website, by copying the page structure of the [Bouvet Island](https://kubernetescommunitydays.org/events/2020-bouvet-island/) event. Here are [directions](organizing-creating-website) to do so.
 
 ## Event Details 
-Most events are developer-focused. Some are more focused on business issues and cloud strateg, 
+Most events are developer-focused. Some are more focused on business issues and cloud strategy.
 
 Similar events have 100-400 attendees. Most start small and grow each year. 
 
@@ -46,18 +45,26 @@ That said, many (most?) talks will be about how companies relied on open source 
 
 If the event creates a profit, it needs to be held and reinvested in future years. Organizers should aim to get all of their actual expenses reimbursed, but not their time.
 
+Other considerations:
+
+* Encourage bold, innovative, thought-provoking subjects
+* Events usually have four 30-minute talks per day
+* Open space sessions are scheduled during the conference, not ahead of time (have attendees vote on topics during the event)
+* Consider offering special pricing such as early bird registration and promotional pricing
+* The event must be at least a one day long
+* Set and monitor bank accounts, online payments (PayPal, etc.), and registration (Eventbrite)
+* Attendance needs to be available to anyone until the availaibty capacity is sold out 
+* Always sensitive and appropriate
+* Have fun and promote fun
+* Encourage interaction
+* The attendee list may not be used for commercial or marketing purposes. It may only be used to advertise that specific Kubernetes Community Day or further iterations of it. The list may not be shared with third parties who are not directly involved in organizing the event. Please review the [Privacy Policy Statement](https://www.linuxfoundation.org/privacy/).
+* Sponsors are allowed to collect attendee information at their tables
+* We recommend event organizers add the following statement to the registration page: “Personal information gathered by the organizers is handled in accordance with the Foundation’s Privacy Policy and is used for internal purposes only.  The Kubernetes Community Privacy Policy is available at [Privacy Policy Statement](https://www.linuxfoundation.org/privacy/).
+
 ## Logos and Trademarks
 Once your event has been accepted (i.e., shows up on [kubernetescommunitydays.org](https://kubernetescommunitydays.org)), you are authorized by CNCF to use that name (e.g., Kubernetes Community Days Bouvet Island). We encourage you to design a custom logo for your event. Please note that the logo can’t include all or part of the Kubernetes wheel, but does need to include the event name. You are welcome to include the CNCF logo in your event logo and graphics, and you’re also welcome to use [Phippy](https://phippy.io/) and friends (high-res versions available in the artwork [repo](https://github.com/cncf/artwork/blob/master/examples/other.md#phippy--friends-group-logos)).
 
 Please post your logo in SVG format, as [explained](https://www.cncf.io/blog/2019/07/17/what-image-formats-should-you-be-using-in-2019/) in this blog post.
-  
-* Consider offering special pricing such as early bird registration and promotional pricing
-* The event must be at least a one day long
-* Set and monitor bank accounts, online payments (PayPal, etc.) and registration (Eventbrite)
-* Attendance needs to be available to anyone until the availaibty capacity is sold out 
-* The attendee list may not be used for commercial or marketing purposes. It may only be used to advertise that specific Kubernetes Community Day or further iterations of it. The list may not be shared with third parties who are not directly involved in organizing the event. Please review the [Kubernetes Community Privacy Policy Statement](http://www.Kubernetes Community.org/privacy).
-* Sponsors are allowed to collect attendee information at their tables
-* We recommend event organizers add the following statement to the registration page: “Personal information gathered by the organizers is handled in accordance with the Foundation’s Privacy Policy and is used for internal purposes only.  The Kubernetes Community Privacy Policy is available at [http://www.Kubernetes Community.org/privacy](http://www.Kubernetes Community.org/privacy).
  
 # Kubernetes Community Days Branding:  
 * All event promotions must be called Kubernetes Community Days Bouvet Island, with Buovet Island replaced by the location of the event. 
@@ -65,104 +72,18 @@ Please post your logo in SVG format, as [explained](https://www.cncf.io/blog/201
 # Assembling Your Team
 In the Kubernetes Community Days spirit of collaboration, find people in your region that want to help you run the next awesome event. For your local organizing team, we suggest you have  focus on specific areas.
 
-* Person/Pair managing finance and budgeting
-* Person/Pair managing marketing and promotion  
-* Person/Pair managing sponsors
-* Person/Pair managing CFP proposals
+* Person/Pair managing finance and budgeting, [learn more](organizing-budget-finances) 
+* Person/Pair managing marketing and promotion, [learn more](organizing-marketing-promotion) 
+* Person/Pair managing sponsors, [learn more](organizing-finding-sponsors)
+* Person/Pair managing CFP proposals, [learn more](organizing-manage-speakers)
 * Person/Pair managing website updates
 * Person/Pair managing registration
-* Person/Pair managing venue, catering, local things, hotel
-* Person/Pair managing t-shirts
+* Person/Pair managing venue, catering, local things, hotel, [learn more](/organizing-timeline)
+* Person/Pair managing t-shirts, swag
 * Person/Pair managing evening event logistics
-
-## Budget and Finances 
-Basic guidelines
-
-* Add up the budgets (venue, food, parties space, schwag) to generate a total event budget to determine the amount of money needed to cover costs
-* Plan on covering most of the expenses through sponsorships to keep ticket prices low
-* Ticket prices should generally be somewhere between $50 and $100, depending on location and event costs 
-* Allocate some budget for scholarships/discounts for students and underrepresented groups
-* Allow 10% overage as there are often unexpected costs
-
-Role of finance team/lead
-
-* Set-up online payments to allow sponsors to pay directly (and avoid procurement and paper checks)
-* Set and monitor bank accounts, online payments (PayPal, etc) and registration (Eventbrite)
-* Invoice sponsors and accepting payments 
-* Accept money from sponsors (and issue official invoices)
-* Move money between accounts as needed to pay suppliers like the venue, catering, swag, etc.
-
-Finance management options
-
-* Option 1: the organizer's companies serve as the finacial sponsor. 
-* Option 2: Use a fiscal sponsor, which generally takes a 10% fee. LIST TEH
-* This may be one of the companies of a volunteer or core organizing team
-* Generally, finance sponsor collects 8-10% overhead Option 2 - designate someone on the team to run finances
-* Time-consuming and tedious - we recommend that a finance sponsor be secured for the first year of the event 
-Rewrite this section. Option 1 is to have one of the organizer's companies serve as finance sponsor. Option 2 is to use a fiscal sponsor, which generally take a 10% fee.[ List the ones recommended by DevOpsDays.]
-
-## Marketing & Promotion
-Role of the Marketing Team
-
-* Drive interest in the event
-* Drive ticket sales
-* Promote event content and speakers
-* Run social promotions, email promotions, blogs and ads
-* Highlight event diversity
-* Manage site content via this website 
-
-Promotion
-
-* Who can help spread the word that the event is scheduled?
- * CNCF via Twitter 
- * Local tech companies and consultants?
- * Local tech publications (if your community has one)
- * Local tech incubators and VCs
- * Local universities (if they have CS departments, for example)
- * Local Meetups
- * Code academies
- * Sponsor companies
-
-Online marketing
-
-* Sponsors corporate newsletters
-* Twitter
-* LinkedIn
-
-# Sponsorship
-Role of sponsorship team/lead
-
-* Identify likely sponsors
-* Inquire whether those sponsors will contribute
-
-Guidelines and rules
-
-* Sponsorship does not equal speaking slot
-* Sponsors will need to pay upfront to make the event work
-* Sponsors cannot commercialize the event
-* Sponsorship should cover 80-90% of total even budget
-* Signing up sponsorships is a lot of work - two volunteers are better than one 
-* Anchor sponsors will make it easy to get follow-on sponsors
-* Sponsorship team works very closely with the finance team
-
-Setting up sponsorship offerings
-
-* Sponsorship tier structure
-* Sample prospectus template <link>
-* The standard is Platinum, Gold, Silver, etc
-* Additional sponsorship opportunities include - the coffee breaks, the happy hour, conference schwag, lunch
-* Feel free to be creative with sponsorship offerings
-* Be very clear in communicating with sponsors what they are getting and what the are NOT getting
-
-Seeking out sponsorships
-
-* Ideally one of the organizers will work for a sponsor
-* Identify local companies that might want to sponsor
-* Often CNCF members really like to sponsor community events (it builds their community cred)
 
 # Kubernetes Community Days Planning Tools
 
-* Kubernetes Community Days Sponsorship and Guidelines. Review and complete this document once organizers and three sponsors have been secured. 
 * [Conference Planning Guide](/organizing-timeline). Use this document to plan out the event timeline. 
 * [Conference Action Items and Checklist](https://drive.google.com/open?id=1bvCiyyDut1seSnBE6pzVevcJkXLeWbxbncvhFsyY8PI). Make a copy of this Google Doc to use as a template for check-in meetings to ensure everyone is on task for a successful event. 
 * [Sponsorship Letter](/organizing-sponsorletter). Use this letter to send out to prospective sponsors.


### PR DESCRIPTION
I moved bullets  under basic guidelines under "other considerations" under event details
I pulled the details of the various teams into their own pages. I will work on copy for the remaining teams and get those added. 
All the links are working (on the "directions" page I still need to flush that out this week. It will be udpated then.