### PR TITLE
Update organizing

### DIFF
--- a/content/organizing.md
+++ b/content/organizing.md
@@ -31,7 +31,7 @@ This quick start guide covers all aspects of holding a successful event. Please 
 
 Once your team meets these criteria, you can create a GitHub [issue](https://github.com/cncf/kubernetes-community-days/issues/new?assignees=christinevblum%2C+iennae&labels=newevent&template=host.md) to notify CNCF that you wish to be officially recognized. Your organizing team will be invited to the [#kcd-organizers](https://cloud-native.slack.com/messages/GN6R2PV1A) private Slack channel where you can connect with other Kubernetes Community Days organizers around the world. You can then begin creating your website. Copy the page structure of the [Bouvet Island](/events/2020-bouvet-island) sample event as a guide. Here’s [instructions](/organizing-creating-website).
 
-* For the launch of KCD, we want to ensure that all KCD Organizers use a set of software that CNCF is familiar with, can help support, and that enables KCD Organizers from different cities to support each other. Additional we understand the privacy policies of the tools we have selected and are able to ensure that all organizers working together are on the same footing. 
+*  For the launch of KCD, we want to ensure that all KCD Organizers use a set of software that CNCF is familiar with, can help support, and that enables KCD Organizers from different cities to support each other. Additional we understand the privacy policies of the tools we have selected and are able to ensure that all organizers working together are on the same footing. 
 
 We acknowledge that there are many tools to choose from when setting up your local KCD event and that this may make being a KCD organizer more difficult for organizers that already have standardized on other tools. 
 

--- a/content/organizing.md
+++ b/content/organizing.md
@@ -20,16 +20,24 @@ This quick start guide covers all aspects of holding a successful event. Please 
 ## Getting Started Checklist
 
 * Verify that no other Kubernetes Community Day events are planned in your local area
-* Have a minimum of 3 local organizers (5 is recommended) from at least 3 different organizations. Each organizer needs to live in or just outside of the KCD location. 
-* Have a minimum of 3 sponsors
+* Have a minimum of 3 local organizers (5 is recommended) from at least 3 different organizations. Each organizer needs to live in or just outside of the KCD location.
+* Have a minimum of 3 sponsors**
 * Make sure that at least one organizer is an employee of a CNCF [member](https://www.cncf.io/about/members/), an [Ambassador](https://www.cncf.io/people/ambassadors/), or a CNCF project [maintainer](https://docs.google.com/spreadsheets/u/1/d/1Pr8cyp8RLrNGx9WBAgQvBzUUmqyOv69R7QAFKhacJEM/)
 * Have a method to accept payments (sponsorships, tickets) and make payments (catering, A/V, other costs)
 * Verify that all organizers have agreed to these event guidelines and to abide by the Kubernetes Community Day [Code of Conduct](/code-of-conduct/)
 * Schedule an event date a minimum of 6 months after  you file your event request with CNCF request submission,  (9 months prior is preferable)
-* Agree to use [Eventbrite](https://www.eventbrite.com/) for registration
-* Agree to use [Sched](https://sched.com) for organizing the program page
+* Agree to use [Eventbrite](https://www.eventbrite.com/) for registration*
+* Agree to use [Sched](https://sched.com) for organizing the program page*
 
-Once your team meets these criteria, you can create a GitHub [issue](https://github.com/cncf/kubernetes-community-days/issues/new?assignees=christinevblum%2C+iennae&labels=newevent&template=host.md) to notify CNCF that you wish to be officially recognized. Your organizing team will be invited to the [#kcd-organizers](https://cloud-native.slack.com/messages/GN6R2PV1A) private Slack channel where you can connect with other Kubernetes Community Days organizers around the world. You can then begin creating your website. Copy the page structure of the [Bouvet Island](/events/2020-bouvet-island) sample event as a guide. Here’s [instructions](/organizing-creating-website) .
+Once your team meets these criteria, you can create a GitHub [issue](https://github.com/cncf/kubernetes-community-days/issues/new?assignees=christinevblum%2C+iennae&labels=newevent&template=host.md) to notify CNCF that you wish to be officially recognized. Your organizing team will be invited to the [#kcd-organizers](https://cloud-native.slack.com/messages/GN6R2PV1A) private Slack channel where you can connect with other Kubernetes Community Days organizers around the world. You can then begin creating your website. Copy the page structure of the [Bouvet Island](/events/2020-bouvet-island) sample event as a guide. Here’s [instructions](/organizing-creating-website).
+
+* For the launch of KCD, we want to ensure that all KCD Organizers use a set of software that CNCF is familiar with, can help support, and that enables KCD Organizers from different cities to support each other. Additional we understand the privacy policies of the tools we have selected and are able to ensure that all organizers working together are on the same footing. 
+
+We acknowledge that there are many tools to choose from when setting up your local KCD event and that this may make being a KCD organizer more difficult for organizers that already have standardized on other tools. 
+
+In China and other areas where our standard tools are blocked, we will work with KCD organizes to determine the best alternatives. 
+
+** For the launch, we want to ensure that each KCD is successful. Part of ensuring the success of the event is to have the first 3 sponsors committed. We acknowledge requiring KCD Organizers to have 3 sponsors committed prior to the approval of your event can be challenging.
 
 ## Event Details 
 

--- a/content/organizing.md
+++ b/content/organizing.md
@@ -31,11 +31,9 @@ This quick start guide covers all aspects of holding a successful event. Please 
 
 Once your team meets these criteria, you can create a GitHub [issue](https://github.com/cncf/kubernetes-community-days/issues/new?assignees=christinevblum%2C+iennae&labels=newevent&template=host.md) to notify CNCF that you wish to be officially recognized. Your organizing team will be invited to the [#kcd-organizers](https://cloud-native.slack.com/messages/GN6R2PV1A) private Slack channel where you can connect with other Kubernetes Community Days organizers around the world. You can then begin creating your website. Copy the page structure of the [Bouvet Island](/events/2020-bouvet-island) sample event as a guide. Here’s [instructions](/organizing-creating-website).
 
-*  For the launch of KCD, we want to ensure that all KCD Organizers use a set of software that CNCF is familiar with, can help support, and that enables KCD Organizers from different cities to support each other. Additional we understand the privacy policies of the tools we have selected and are able to ensure that all organizers working together are on the same footing. 
+*  For the launch of KCD, we are standardizing on familiar tools to enable CNCF support and KCD Organizers to support each other. We understand the challenge of using new services and the specific privacy policies of the selected software.
 
-We acknowledge that there are many tools to choose from when setting up your local KCD event and that this may make being a KCD organizer more difficult for organizers that already have standardized on other tools. 
-
-In China and other areas where our standard tools are blocked, we will work with KCD organizes to determine the best alternatives. 
+Where our standard tools are blocked, CNCF will work with KCD organizers to determine alternatives. 
 
 ** For the launch, we want to ensure that each KCD is successful. Part of ensuring the success of the event is to have the first 3 sponsors committed. We acknowledge requiring KCD Organizers to have 3 sponsors committed prior to the approval of your event can be challenging.
 


### PR DESCRIPTION
Added caveats to the "getting started section. Dan the first bullet that was added needs to appear as a "*" how do I do this? 

Added: 
* For the launch of KCD, we want to ensure that all KCD Organizers use a set of software that CNCF is familiar with, can help support, and that enables KCD Organizers from different cities to support each other. Additional we understand the privacy policies of the tools we have selected and are able to ensure that all organizers working together are on the same footing. 

We acknowledge that there are many tools to choose from when setting up your local KCD event and that this may make being a KCD organizer more difficult for organizers that already have standardized on other tools. 

In China and other areas where our standard tools are blocked, we will work with KCD organizes to determine the best alternatives. 

** For the launch, we want to ensure that each KCD is successful. Part of ensuring the success of the event is to have the first 3 sponsors committed. We acknowledge requiring KCD Organizers to have 3 sponsors committed prior to the approval of your event can be challenging.
