### PR TITLE
[AMS-2019] Add missing country

### DIFF
--- a/content/events/2019-amsterdam/_index.md
+++ b/content/events/2019-amsterdam/_index.md
@@ -3,6 +3,7 @@ title: Amsterdam
 date: 2019-09-13
 location:
   city: Amsterdam
+  country: The Nederlands
   url: https://dezwijger.nl
   venue: Pakhuis De Zwijger
 social:


### PR DESCRIPTION
Fixes the missing country field for the AMS 2019 event.