### PR TITLE
Add country codes for RSS feed

### DIFF
--- a/content/events/2019-amsterdam/_index.md
+++ b/content/events/2019-amsterdam/_index.md
@@ -5,7 +5,7 @@ end: ''
 location:
   city: Amsterdam
   country: The Netherlands
-  country-code: nl
+  countrycode: nl
   url: https://dezwijger.nl
   venue: Pakhuis De Zwijger
 map: amsterdam-map.png

--- a/content/events/2019-amsterdam/_index.md
+++ b/content/events/2019-amsterdam/_index.md
@@ -5,6 +5,7 @@ end: ''
 location:
   city: Amsterdam
   country: The Netherlands
+  country-code: nl
   url: https://dezwijger.nl
   venue: Pakhuis De Zwijger
 map: amsterdam-map.png

--- a/content/events/2020-amsterdam/_index.md
+++ b/content/events/2020-amsterdam/_index.md
@@ -5,6 +5,7 @@ end: '2020-09-25'
 location:
   country: The Netherlands
   city: Amsterdam
+  country-code: nl
   url: https://www.amsterdam.nl/
   venue: Westergasterras
 map: amsterdam-map.png

--- a/content/events/2020-amsterdam/_index.md
+++ b/content/events/2020-amsterdam/_index.md
@@ -5,7 +5,7 @@ end: '2020-09-25'
 location:
   country: The Netherlands
   city: Amsterdam
-  country-code: nl
+  countrycode: nl
   url: https://www.amsterdam.nl/
   venue: Westergasterras
 map: amsterdam-map.png

--- a/content/events/2020-portland-oregon/_index.md
+++ b/content/events/2020-portland-oregon/_index.md
@@ -2,7 +2,7 @@
 title: Portland, Oregon
 date: '2020-09-12'
 location:
-  country-code: us
+  countrycode: us
   country: United States
   city: Portland, Oregon
   url: http://cnpdx.us/

--- a/content/events/2020-portland-oregon/_index.md
+++ b/content/events/2020-portland-oregon/_index.md
@@ -2,6 +2,7 @@
 title: Portland, Oregon
 date: '2020-09-12'
 location:
+  country-code: us
   country: United States
   city: Portland, Oregon
   url: http://cnpdx.us/

--- a/content/events/2025-bouvet-island/_index.md
+++ b/content/events/2025-bouvet-island/_index.md
@@ -3,6 +3,7 @@ title: Bouvet Island
 date: '2025-01-01'
 end: '2025-01-02'
 location:
+  country-code: bv
   country: Antarctica
   city: Bouvet Island
   url: https://en.wikipedia.org/wiki/Bouvet_Island

--- a/content/events/2025-bouvet-island/_index.md
+++ b/content/events/2025-bouvet-island/_index.md
@@ -3,7 +3,7 @@ title: Bouvet Island
 date: '2025-01-01'
 end: '2025-01-02'
 location:
-  country-code: bv
+  countrycode: bv
   country: Antarctica
   city: Bouvet Island
   url: https://en.wikipedia.org/wiki/Bouvet_Island

--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -70,6 +70,9 @@
       <country>
         {{ . }}
       </country>
+      <country-code>
+        {{ . }}
+      </country-code>
       {{ end }}
       {{ with .city }}
       <city>

--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -71,10 +71,10 @@
         {{ . }}
       </country>
       {{ end }}
-      {{ with .country-code }}
-      <country-code>
+      {{ with .countrycode }}
+      <countrycode>
         {{ . }}
-      </country-code>
+      </countrycode>
       {{ end }}
       {{ with .city }}
       <city>

--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -70,6 +70,8 @@
       <country>
         {{ . }}
       </country>
+      {{ end }}
+      {{ with .country-code }}
       <country-code>
         {{ . }}
       </country-code>


### PR DESCRIPTION
Signed-off-by: Dan Kohn <dan@dankohn.com>

Country codes will be served by the RSS feed and used by https://events.linuxfoundation.org/about/community/ to show the country dropdown correctly.

We're using ISO-3166-1 two-letter country codes: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements