### PR TITLE
Adapt amsterdam CFP deadline to date mentioned text

### DIFF
--- a/content/events/2021-amsterdam/_index.md
+++ b/content/events/2021-amsterdam/_index.md
@@ -63,7 +63,7 @@ organizers:
 organizers_email: organizers-amsterdam@kubernetescommunitydays.org
 local_law_enforcement: 112
 medical_emergency: 112
-cfp_deadline: '2020-12-01'
+cfp_deadline: '2021-04-15'
 sponsor_deadline: '2021-03-30'
 ---
 


### PR DESCRIPTION
I considered answering to the CFP but am slightly confused by lots of different dates whirling around.

* Text changes from #369 mentions the CFP remaining open until "15th of April 2021"
* [Speaking page](https://kubernetescommunitydays.org/speaking/) says CFP closed "December 1, 2020"
* [Sessionize](https://sessionize.com/kcdams2021/) claims CFP closes "15 Dec 2020", but also " event starts 08 Apr 2021"

So my common sense tells me
* CFP open until 2021-04-15
* Event starts 2021-09-09

Is that correct @ams0? If so, please adapt sessionize page.
