### PR TITLE
Update platform to Sessionize

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We are now hosting *a monthly KCD Organizer focus group*. As of now, it will be 
 
 * A personalized email address and private CNCF workspace Slack channel for the KCD organizers
 * Website and ticket support for community.cncf.io (Bevy platform)
-* CFP support with the SM Apply platform
+* CFP support with the Sessionize platform
 * Monthly meetings to help keep you on track
 * Access to monthly CNCF-hosted Working Groups
 * Speaker and vendor introductions as needed
@@ -54,7 +54,7 @@ NOTE: These are the terms within the checklist that are IMPORTANT to abide by:
 * Agree to ensure the final program schedule is diverse (e.g., not all speakers of one gender, culture or company). [Here is how you can create a diverse lineup.](https://docs.google.com/presentation/d/1fzT_BdavVKh3mnxxU-PBWyJq9JUfasKwHqekkbYVbw8/edit#slide=id.g56245ab439_0_106)
 * Agree to submit your final lineup to kcd@cncf.io for review, prior to publishing it
 * Agree to use Bevy (Cloud Native Community Groups) for registration, scheduling, and event website. NOTE: If you chose to use another registration platform, you must report your weekly registration numbers in the #kcd-organizers private Slack channel within the CNCF workspace.
-* Agree to use SM Apply for CFP and to close it at least 6 weeks before the event
+* Agree to use Sessionize for CFP and to close it at least 6 weeks before the event
 
 STEP 2: Request to be added to the [kcd-organizers](https://cloud-native.slack.com/archives/GQ7D26NPQ) CNCF Slack channel.
 


### PR DESCRIPTION
Platform update: https://www.cncf.io/blog/2023/04/26/introducing-sessionize-a-new-cfp-platform-for-cncf-events/