### PR TITLE
sponsor-resources/badge-scanning.md: Add F-droid alternative

### DIFF
--- a/sponsor-resources/badge-scanning.md
+++ b/sponsor-resources/badge-scanning.md
@@ -4,6 +4,7 @@ As a KCD you are allowed to offer lead scanning on-site at your event, as this i
 
 Past and current organizers have shared success with the following:
 * Generation of conference badges through this open source python program CNCF Ambassador William Rizzo generated, called [ConfBadger](https://github.com/wrkode/ConfBadger)
-* For the actual software running on your phone, KCD UK (5x KCD in 2025) has had success using https://www.badgerscan.org/
+* For the actual software running on your phone, KCD UK (5x KCD in 2025) has had success using https://www.badgerscan.org/. Badgerscan is not installable on modern Android phones in its current state.
+* Android phones with F-droid can use [QR & Barcode Scanner](https://f-droid.org/packages/com.example.barcodescanner/). The app allows the user to export the history as CSV or json and data is stored locally on the device.
 
 An on-site badge template for your attendees to wear can be [found in Canva here](https://www.canva.com/design/DAGDholi8n8/H5jrZt9T1D3H_OpV07Hsnw/view?utm_content=DAGDholi8n8&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h9db5bc675f).


### PR DESCRIPTION
Hello!

I spent the weekend trying to figure out which application android users could use for leadscanning.

The Badgerscanner application seems abandoned, and is not installable on modern android phones.